### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 dependencies = [
  "jobserver",
  "libc",
@@ -2176,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "gilrs"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f226b8f4d9bc7da93de8efd8747c6b1086409ca3f4b6d51e9a7f5461a9183fe"
+checksum = "dfb8c78963a8856a5b10015c9349176ff5edbc8095384d52aada467a848bc03a"
 dependencies = [
  "fnv",
  "gilrs-core",
@@ -3016,18 +3016,18 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3548,7 +3548,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "reactor_camera"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bevy",
  "reactor_spatial",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "reactor_core"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "bevy",
  "bevy_mod_picking",
@@ -3581,7 +3581,7 @@ dependencies = [
 
 [[package]]
 name = "reactor_proto"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "bevy",
  "bevy_common_assets",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "reactor_serial"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrayref",
  "bevy",
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "reactor_spatial"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bevy",
  "reactor_random",
@@ -3843,11 +3843,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -4301,9 +4302,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ categories = ["game-engines"]
 reactor_spatial = { path = "crates/reactor_spatial", version = "1.0" }
 reactor_ui = { path = "crates/reactor_ui", version = "1.0" }
 reactor_perf_ui = { path = "crates/reactor_perf_ui", version = "1.0" }
-reactor_proto = { path = "crates/reactor_proto", version = "1.0" }
+reactor_proto = { path = "crates/reactor_proto", version = "1.1" }
 reactor_random = { path = "crates/reactor_random", version = "1.0" }
 reactor_serial = { path = "crates/reactor_serial", version = "1.0" }
 reactor_camera = { path = "crates/reactor_camera", version = "1.0" }
-reactor_core = { path = "crates/reactor_core", version = "1.0" }
+reactor_core = { path = "crates/reactor_core", version = "1.1" }
 ##########
 
 ########## BEVY (or likely upstreamed eventually)

--- a/crates/reactor_camera/CHANGELOG.md
+++ b/crates/reactor_camera/CHANGELOG.md
@@ -5,3 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.1](https://github.com/Cobalt-Reactor/cobalt-reactor/compare/reactor_camera-v1.0.0...reactor_camera-v1.0.1) - 2024-07-29
+
+### 2. Bug fixes
+- Renaming plugins to avoid name collisions with some third party crates

--- a/crates/reactor_camera/Cargo.toml
+++ b/crates/reactor_camera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactor_camera"
-version = "1.0.0"
+version = "1.0.1"
 readme = "README.md"
 description = "A 2D camera plugin for Bevy, inspired by the Love2D camera plugin - STALKER-X"
 authors.workspace = true

--- a/crates/reactor_core/CHANGELOG.md
+++ b/crates/reactor_core/CHANGELOG.md
@@ -5,3 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.0](https://github.com/Cobalt-Reactor/cobalt-reactor/compare/reactor_core-v1.0.0...reactor_core-v1.1.0) - 2024-07-29
+
+### 1. New features
+- Adding reactor_perf_ui to reactor_core
+- Added entity_builder to world
+- `entity_builder` added to Commands
+- Changed EntityBuilder to install modules immediately, and no longer requires you to call build
+- Final UI Perf PAnel
+- Complete set of perf counters added to reactor_perf_ui
+- Added a bunch of useful reexports from bevy
+- floating window
+- reactor_perf_ui now has a plugin
+
+### 2. Bug fixes
+- Renaming plugins to avoid name collisions with some third party crates

--- a/crates/reactor_core/Cargo.toml
+++ b/crates/reactor_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactor_core"
-version = "1.0.0"
+version = "1.1.0"
 readme = "README.md"
 description = "A combined suite of tools provided by reactor for use with the Bevy game engine."
 authors.workspace = true

--- a/crates/reactor_perf_ui/CHANGELOG.md
+++ b/crates/reactor_perf_ui/CHANGELOG.md
@@ -5,3 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0](https://github.com/Cobalt-Reactor/cobalt-reactor/releases/tag/reactor_perf_ui-v1.0.0) - 2024-07-29
+
+### 1. New features
+- Final UI Perf PAnel
+- Complete set of perf counters added to reactor_perf_ui
+- reactor_perf_ui now has a plugin
+- floating window

--- a/crates/reactor_proto/CHANGELOG.md
+++ b/crates/reactor_proto/CHANGELOG.md
@@ -5,3 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.0](https://github.com/Cobalt-Reactor/cobalt-reactor/compare/reactor_proto-v1.0.0...reactor_proto-v1.1.0) - 2024-07-29
+
+### 1. New features
+- Added entity_builder to world
+- `entity_builder` added to Commands
+- Changed EntityBuilder to install modules immediately, and no longer requires you to call build
+
+### 2. Bug fixes
+- Renaming plugins to avoid name collisions with some third party crates

--- a/crates/reactor_proto/Cargo.toml
+++ b/crates/reactor_proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactor_proto"
-version = "1.0.0"
+version = "1.1.0"
 readme = "README.md"
 description = "An opinionated rust library for transforming on-disk assets into Entities in Bevy."
 authors.workspace = true

--- a/crates/reactor_serial/CHANGELOG.md
+++ b/crates/reactor_serial/CHANGELOG.md
@@ -5,3 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.1](https://github.com/Cobalt-Reactor/cobalt-reactor/compare/reactor_serial-v1.0.0...reactor_serial-v1.0.1) - 2024-07-29
+
+### 2. Bug fixes
+- Renaming plugins to avoid name collisions with some third party crates

--- a/crates/reactor_serial/Cargo.toml
+++ b/crates/reactor_serial/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactor_serial"
-version = "1.0.0"
+version = "1.0.1"
 readme = "README.md"
 description = "A plugin for Bevy for handling saving and loading"
 authors.workspace = true

--- a/crates/reactor_spatial/CHANGELOG.md
+++ b/crates/reactor_spatial/CHANGELOG.md
@@ -5,3 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.1](https://github.com/Cobalt-Reactor/cobalt-reactor/compare/reactor_spatial-v1.0.0...reactor_spatial-v1.0.1) - 2024-07-29
+
+### 2. Bug fixes
+- Renaming plugins to avoid name collisions with some third party crates

--- a/crates/reactor_spatial/Cargo.toml
+++ b/crates/reactor_spatial/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactor_spatial"
-version = "1.0.0"
+version = "1.0.1"
 readme = "README.md"
 description = "A set of 2D spatial utilities for Bevy, including handling transform propagation"
 authors.workspace = true

--- a/crates/reactor_ui/CHANGELOG.md
+++ b/crates/reactor_ui/CHANGELOG.md
@@ -5,3 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0](https://github.com/Cobalt-Reactor/cobalt-reactor/releases/tag/reactor_ui-v1.0.0) - 2024-07-29
+
+### 1. New features
+- Final UI Perf PAnel
+- Complete set of perf counters added to reactor_perf_ui
+- Added a bunch of useful reexports from bevy
+- Adding reactor_perf_ui to reactor_core
+- floating window


### PR DESCRIPTION
## 🤖 New release
* `reactor_core`: 1.0.0 -> 1.1.0
* `reactor_camera`: 1.0.0 -> 1.0.1
* `reactor_spatial`: 1.0.0 -> 1.0.1
* `reactor_perf_ui`: 1.0.0
* `reactor_ui`: 1.0.0
* `reactor_proto`: 1.0.0 -> 1.1.0
* `reactor_serial`: 1.0.0 -> 1.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `reactor_core`
<blockquote>

## [1.1.0](https://github.com/Cobalt-Reactor/cobalt-reactor/compare/reactor_core-v1.0.0...reactor_core-v1.1.0) - 2024-07-29

### 1. New features
- Adding reactor_perf_ui to reactor_core
- Added entity_builder to world
- `entity_builder` added to Commands
- Changed EntityBuilder to install modules immediately, and no longer requires you to call build
- Final UI Perf PAnel
- Complete set of perf counters added to reactor_perf_ui
- Added a bunch of useful reexports from bevy
- floating window
- reactor_perf_ui now has a plugin

### 2. Bug fixes
- Renaming plugins to avoid name collisions with some third party crates
</blockquote>

## `reactor_camera`
<blockquote>

## [1.0.1](https://github.com/Cobalt-Reactor/cobalt-reactor/compare/reactor_camera-v1.0.0...reactor_camera-v1.0.1) - 2024-07-29

### 2. Bug fixes
- Renaming plugins to avoid name collisions with some third party crates
</blockquote>

## `reactor_spatial`
<blockquote>

## [1.0.1](https://github.com/Cobalt-Reactor/cobalt-reactor/compare/reactor_spatial-v1.0.0...reactor_spatial-v1.0.1) - 2024-07-29

### 2. Bug fixes
- Renaming plugins to avoid name collisions with some third party crates
</blockquote>

## `reactor_perf_ui`
<blockquote>

## [1.0.0](https://github.com/Cobalt-Reactor/cobalt-reactor/releases/tag/reactor_perf_ui-v1.0.0) - 2024-07-29

### 1. New features
- Final UI Perf PAnel
- Complete set of perf counters added to reactor_perf_ui
- reactor_perf_ui now has a plugin
- floating window
</blockquote>

## `reactor_ui`
<blockquote>

## [1.0.0](https://github.com/Cobalt-Reactor/cobalt-reactor/releases/tag/reactor_ui-v1.0.0) - 2024-07-29

### 1. New features
- Final UI Perf PAnel
- Complete set of perf counters added to reactor_perf_ui
- Added a bunch of useful reexports from bevy
- Adding reactor_perf_ui to reactor_core
- floating window
</blockquote>

## `reactor_proto`
<blockquote>

## [1.1.0](https://github.com/Cobalt-Reactor/cobalt-reactor/compare/reactor_proto-v1.0.0...reactor_proto-v1.1.0) - 2024-07-29

### 1. New features
- Added entity_builder to world
- `entity_builder` added to Commands
- Changed EntityBuilder to install modules immediately, and no longer requires you to call build

### 2. Bug fixes
- Renaming plugins to avoid name collisions with some third party crates
</blockquote>

## `reactor_serial`
<blockquote>

## [1.0.1](https://github.com/Cobalt-Reactor/cobalt-reactor/compare/reactor_serial-v1.0.0...reactor_serial-v1.0.1) - 2024-07-29

### 2. Bug fixes
- Renaming plugins to avoid name collisions with some third party crates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).